### PR TITLE
feat(mcpb): add MCPB bundle manifest for Smithery / Claude Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The CockroachDB MCP Server is a **natural language interface** designed for LLMs
   - [Quick Start with uvx](#quick-start-with-uvx)
   - [Development Installation](#development-installation)
   - [With Docker](#with-docker)
+  - [As an MCPB Bundle (Smithery / Claude Desktop)](#as-an-mcpb-bundle-smithery--claude-desktop)
 - [Configuration](#configuration)
   - [Configuration via command line arguments](#configuration-via-command-line-arguments)
   - [Configuration via Environment Variables](#configuration-via-environment-variables)
@@ -451,6 +452,28 @@ Finally, configure the client to create the container at start-up. An example fo
 ```
 
 To use the [CockroachDB MCP Docker](https://hub.docker.com/mcp/server/cockroachdb) image, just replace your image name (`mcp-cockroachdb` in the example above) with `mcp/cockroachdb`.
+
+### As an MCPB Bundle (Smithery / Claude Desktop)
+
+The repository ships an [MCPB](https://github.com/anthropics/mcpb) manifest under `mcpb/manifest.json`. MCPB (`.mcpb`) is a single-file archive that clients like Claude Desktop and catalogs like [Smithery](https://smithery.ai) can install as a local stdio server, prompting the user for connection details via a UI instead of hand-editing JSON.
+
+The manifest declares six `user_config` fields: `url` (marked `sensitive`, so the client stores it in the OS keychain rather than plaintext config), `read_only` (default `true`), `allow_destructive` (default `false`), and optional `ssl_ca_cert` / `ssl_cert` / `ssl_key` file pickers. Values are passed to the server via env vars (`CRDB_URL`, `MCP_READ_ONLY`, `MCP_ALLOW_DESTRUCTIVE`, `CRDB_SSL_*`).
+
+**Build the bundle:**
+
+```sh
+npm install -g @anthropic-ai/mcpb
+cp mcpb/manifest.json ./manifest.json
+mcpb pack . cockroachdb-mcp-server.mcpb
+```
+
+**Install locally in Claude Desktop:** double-click the resulting `.mcpb` file. Claude Desktop will show the config form built from `user_config`.
+
+**Publish to Smithery:**
+
+```sh
+smithery mcp publish ./cockroachdb-mcp-server.mcpb -n amineelkouhen/cockroachdb-mcp-server
+```
 
 ## Configuration
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -1,0 +1,109 @@
+{
+  "manifest_version": "0.4",
+  "name": "cockroachdb-mcp-server",
+  "display_name": "CockroachDB MCP Server",
+  "version": "0.2.0",
+  "description": "Natural-language interface for managing, monitoring, and querying CockroachDB from any MCP client.",
+  "long_description": "Exposes CockroachDB as a set of MCP tools organized into thirteen categories: Cluster Monitoring, Database Operations, Table Management, Query Engine, User & Privilege Management, Vector Search (C-SPANN), Job Management, Backup & Restore, Statistics, Multi-Region, Changefeeds, Cluster Admin, and Diagnostics. Ships with a safety layer: strict identifier validation, parameterized values, --read-only mode, --allow-destructive + per-call confirm=True, and DSN redaction in responses.",
+  "author": {
+    "name": "Amine El Kouhen",
+    "url": "https://github.com/amineelkouhen"
+  },
+  "homepage": "https://github.com/amineelkouhen/mcp-cockroachdb",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/amineelkouhen/mcp-cockroachdb"
+  },
+  "license": "MIT",
+  "keywords": ["cockroachdb", "database", "sql", "vector-search", "mcp", "postgres"],
+  "server": {
+    "type": "uv",
+    "entry_point": "src/main.py",
+    "mcp_config": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "${__dirname}",
+        "src/main.py"
+      ],
+      "env": {
+        "CRDB_URL": "${user_config.url}",
+        "MCP_READ_ONLY": "${user_config.read_only}",
+        "MCP_ALLOW_DESTRUCTIVE": "${user_config.allow_destructive}",
+        "CRDB_SSL_CA_PATH": "${user_config.ssl_ca_cert}",
+        "CRDB_SSL_CERTFILE": "${user_config.ssl_cert}",
+        "CRDB_SSL_KEYFILE": "${user_config.ssl_key}"
+      }
+    }
+  },
+  "user_config": {
+    "url": {
+      "type": "string",
+      "title": "CockroachDB connection URL",
+      "description": "postgresql://user:password@host:port/database (add ?sslmode=verify-full&sslrootcert=... for TLS)",
+      "sensitive": true,
+      "required": true
+    },
+    "read_only": {
+      "type": "boolean",
+      "title": "Read-only mode",
+      "description": "Refuse every DDL and write-shaped tool. Recommended for assistant-style deployments.",
+      "default": true,
+      "required": false
+    },
+    "allow_destructive": {
+      "type": "boolean",
+      "title": "Allow destructive operations",
+      "description": "Enable drop_database, drop_table, drop_index, drop_view. Each call must still pass confirm=True. Ignored when read-only is on.",
+      "default": false,
+      "required": false
+    },
+    "ssl_ca_cert": {
+      "type": "file",
+      "title": "SSL CA certificate",
+      "description": "Path to the CA (root) certificate. Only needed when the URL uses sslmode=verify-ca or verify-full without an inline sslrootcert.",
+      "required": false
+    },
+    "ssl_cert": {
+      "type": "file",
+      "title": "SSL client certificate",
+      "description": "Path to the client certificate. Optional; only for cert-based auth.",
+      "required": false
+    },
+    "ssl_key": {
+      "type": "file",
+      "title": "SSL client key",
+      "description": "Path to the client private key. Optional; only for cert-based auth.",
+      "required": false
+    }
+  },
+  "tools": [
+    { "name": "get_cluster_health", "description": "Cluster health and node status." },
+    { "name": "get_running_queries", "description": "Currently running queries." },
+    { "name": "find_slow_queries", "description": "Slow queries from statement statistics." },
+    { "name": "execute_query", "description": "Run a SQL query with JSON/CSV/table output." },
+    { "name": "run_transaction", "description": "Run a multi-statement transaction." },
+    { "name": "explain_query", "description": "Retrieve the query plan for a statement." },
+    { "name": "list_databases", "description": "List databases." },
+    { "name": "create_database", "description": "Create a database." },
+    { "name": "describe_table", "description": "Describe a table's schema and metadata." },
+    { "name": "bulk_import", "description": "Bulk import CSV/Avro data from cloud storage." },
+    { "name": "vector_similarity_search", "description": "Vector similarity search with cosine/L2/inner-product metrics." },
+    { "name": "create_cspann_index", "description": "Create a C-SPANN ANN vector index (v25.2+)." },
+    { "name": "list_jobs", "description": "List async jobs (BACKUP, RESTORE, IMPORT, CHANGEFEED, SCHEMA CHANGE)." },
+    { "name": "create_backup", "description": "Take a full / database / table backup to s3/gs/azure/nodelocal/userfile." },
+    { "name": "restore_backup", "description": "Restore from a backup URI (destructive)." },
+    { "name": "create_changefeed", "description": "Create a CDC changefeed to Kafka / webhook / cloud storage." },
+    { "name": "show_regions", "description": "List cluster regions." },
+    { "name": "set_table_locality", "description": "Set a table's multi-region locality (REGIONAL, REGIONAL_BY_ROW, GLOBAL)." },
+    { "name": "show_cluster_setting", "description": "Read a cluster setting." },
+    { "name": "get_recent_traces", "description": "Recent tracing spans from crdb_internal.cluster_inflight_traces." }
+  ],
+  "compatibility": {
+    "platforms": ["darwin", "linux", "win32"],
+    "runtimes": {
+      "python": ">=3.12"
+    }
+  }
+}

--- a/src/main.py
+++ b/src/main.py
@@ -65,9 +65,11 @@ class CockroachMCPServer:
 @click.version_option(__version__, prog_name="cockroachdb-mcp-server")
 @click.option(
     "--url",
+    envvar="CRDB_URL",
     help=(
         "CockroachDB connection URI "
-        "(postgresql://<user>:<password>@<host>:<port>/<db> or cockroach://...)"
+        "(postgresql://<user>:<password>@<host>:<port>/<db> or cockroach://...). "
+        "Also read from CRDB_URL."
     ),
 )
 @click.option("--host", help="CockroachDB host")
@@ -116,18 +118,21 @@ class CockroachMCPServer:
     "--read-only/--no-read-only",
     default=False,
     show_default=True,
+    envvar="MCP_READ_ONLY",
     help=(
         "Refuse all DDL and write tools (drop_*, create_*, execute_query of "
-        "write statements, etc.)."
+        "write statements, etc.). Also read from MCP_READ_ONLY."
     ),
 )
 @click.option(
     "--allow-destructive/--no-allow-destructive",
     default=False,
     show_default=True,
+    envvar="MCP_ALLOW_DESTRUCTIVE",
     help=(
         "Required for drop_database, drop_table, drop_index, drop_view. "
-        "Even with this flag, callers must pass confirm=True per call."
+        "Even with this flag, callers must pass confirm=True per call. "
+        "Also read from MCP_ALLOW_DESTRUCTIVE."
     ),
 )
 def cli(


### PR DESCRIPTION
## Summary

- Adds `mcpb/manifest.json`: MCPB v0.4 manifest using the `uv` runtime and `src/main.py` as the entry point.
- Six `user_config` fields: `url` (marked `sensitive` so the client stores it in the OS keychain instead of a JSON config file), `read_only` (default `true`), `allow_destructive` (default `false`), and three optional file pickers for TLS certs.
- Values reach the server through env vars (`CRDB_URL`, `MCP_READ_ONLY`, `MCP_ALLOW_DESTRUCTIVE`, `CRDB_SSL_*`) rather than as command-line args, which avoids brittle boolean-string substitution and keeps secrets out of `ps`.
- Small `src/main.py` change: `envvar=` added to `--url`, `--read-only`, and `--allow-destructive` so the env-var wiring above actually takes effect. No behavior change when the flags are passed directly.
- README section explaining `mcpb pack` and `smithery mcp publish` for the local-bundle path.

## Why

Closes the "credentials in JSON config file" gap for the local-install path: the client renders a proper config form, and `sensitive: true` on the URL routes it through the OS keychain instead of `claude_desktop_config.json`. Also lets the server land in the Smithery catalog as an MCPB bundle.

## Test plan

- [ ] `python3 -c "import json; json.load(open('mcpb/manifest.json'))"` — schema is valid JSON.
- [ ] `mcpb pack . cockroachdb-mcp-server.mcpb` — bundle builds.
- [ ] Install the `.mcpb` locally in Claude Desktop, confirm the config form renders all six fields and that the URL field is masked.
- [ ] `MCP_READ_ONLY=true CRDB_URL=postgresql://... uv run cockroachdb-mcp-server` — server starts in read-only mode from env alone.
- [ ] `smithery mcp publish ./cockroachdb-mcp-server.mcpb -n amineelkouhen/cockroachdb-mcp-server` — bundle publishes.