### PR TITLE
chore(mcpb): add .mcpbignore to keep the bundle lean

### DIFF
--- a/.mcpbignore
+++ b/.mcpbignore
@@ -1,0 +1,54 @@
+# Keep the bundle lean. gitignore syntax.
+
+# VCS
+.git/
+.github/
+.gitignore
+.gitattributes
+
+# Python build / cache
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+.eggs/
+build/
+dist/
+
+# Virtual envs
+.venv/
+venv/
+env/
+.python-version
+
+# Test / lint caches
+tests/
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+
+# Docker (not used by the local stdio bundle)
+Dockerfile
+docker-compose.yaml
+docker-compose.yml
+.dockerignore
+
+# Editor / OS
+.vscode/
+.idea/
+.DS_Store
+Thumbs.db
+
+# Secrets
+.env
+.env.local
+*.pem
+*.key
+
+# Prior bundle artifacts
+*.mcpb
+
+# Docs & examples aren't needed at runtime
+examples/


### PR DESCRIPTION
## Summary

Adds `.mcpbignore` so `mcpb pack .` only ships what the bundle actually needs.

**Excluded:** `.git`, `.github`, `.venv`, `tests/`, `.pytest_cache`, `.ruff_cache`, `.mypy_cache`, `__pycache__`, Docker files (unused by the local stdio bundle), editor cruft (`.vscode`, `.idea`, `.DS_Store`), secrets (`.env`, `*.pem`, `*.key`), prior `*.mcpb` artifacts, and `examples/`.

**Kept:** `src/`, `mcpb/manifest.json`, `pyproject.toml`, `uv.lock`, `LICENSE`, `README.md`.

## Test plan

- [ ] `mcpb pack . cockroachdb-mcp-server.mcpb`
- [ ] `unzip -l cockroachdb-mcp-server.mcpb | wc -l` shrinks significantly vs a pack without the ignore file.
- [ ] `unzip -l cockroachdb-mcp-server.mcpb | grep -E "\.venv|\.git|__pycache__|tests/"` returns nothing.