### PR TITLE
fix(mcpb): use type=python so Smithery accepts the bundle

### DIFF
--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -78,28 +78,6 @@
       "required": false
     }
   },
-  "tools": [
-    { "name": "get_cluster_health", "description": "Cluster health and node status." },
-    { "name": "get_running_queries", "description": "Currently running queries." },
-    { "name": "find_slow_queries", "description": "Slow queries from statement statistics." },
-    { "name": "execute_query", "description": "Run a SQL query with JSON/CSV/table output." },
-    { "name": "run_transaction", "description": "Run a multi-statement transaction." },
-    { "name": "explain_query", "description": "Retrieve the query plan for a statement." },
-    { "name": "list_databases", "description": "List databases." },
-    { "name": "create_database", "description": "Create a database." },
-    { "name": "describe_table", "description": "Describe a table's schema and metadata." },
-    { "name": "bulk_import", "description": "Bulk import CSV/Avro data from cloud storage." },
-    { "name": "vector_similarity_search", "description": "Vector similarity search with cosine/L2/inner-product metrics." },
-    { "name": "create_cspann_index", "description": "Create a C-SPANN ANN vector index (v25.2+)." },
-    { "name": "list_jobs", "description": "List async jobs (BACKUP, RESTORE, IMPORT, CHANGEFEED, SCHEMA CHANGE)." },
-    { "name": "create_backup", "description": "Take a full / database / table backup to s3/gs/azure/nodelocal/userfile." },
-    { "name": "restore_backup", "description": "Restore from a backup URI (destructive)." },
-    { "name": "create_changefeed", "description": "Create a CDC changefeed to Kafka / webhook / cloud storage." },
-    { "name": "show_regions", "description": "List cluster regions." },
-    { "name": "set_table_locality", "description": "Set a table's multi-region locality (REGIONAL, REGIONAL_BY_ROW, GLOBAL)." },
-    { "name": "show_cluster_setting", "description": "Read a cluster setting." },
-    { "name": "get_recent_traces", "description": "Recent tracing spans from crdb_internal.cluster_inflight_traces." }
-  ],
   "compatibility": {
     "platforms": ["darwin", "linux", "win32"],
     "runtimes": {

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "keywords": ["cockroachdb", "database", "sql", "vector-search", "mcp", "postgres"],
   "server": {
-    "type": "uv",
+    "type": "python",
     "entry_point": "src/main.py",
     "mcp_config": {
       "command": "uv",


### PR DESCRIPTION
## Summary

Smithery's \`@smithery/cli\` only recognizes \`node\`, \`python\`, or \`binary\` for \`server.type\` in a bundled manifest. Publishing with \`type: uv\` (valid per the MCPB spec, but newer) fails with:

\`\`\`
✗ Could not determine bundle runtime from manifest
\`\`\`

Switching to \`type: python\` unblocks publishing. \`mcp_config.command\` stays \`uv\`, so what actually runs at install time is identical — Smithery just uses the type field for catalog classification.

## Test plan

- [ ] \`mcpb pack . cockroachdb-mcp-server.mcpb\` still works.
- [ ] \`npx -y @smithery/cli mcp publish ./cockroachdb-mcp-server.mcpb -n amineelkouhen/cockroachdb-mcp-server\` succeeds.
- [ ] Local Claude Desktop install of the .mcpb still boots the server (\`uv\` on PATH).